### PR TITLE
Auto-deletion of log files based on config

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Examples:
 * `log/dk-{Y}-{m}-{d}.log` will write every day to a different file (eg: `log/dk-2021-01-01.log`)
 * `log/dk-{Y}-{W}.log` will write every week to a different file (eg: `log/dk-2021-10.log`)
 
-The full list of format specifiers is available [here](https://www.php.net/manual/en/datetime.format.php).
+The full list of format specifiers is available in the [official documentation](https://www.php.net/manual/en/datetime.format.php).
 
 ## Filtering log messages
 

--- a/docs/book/v5/configuring-writer.md
+++ b/docs/book/v5/configuring-writer.md
@@ -23,6 +23,7 @@ return [
                         'level'   => \Dot\Log\Logger::ALERT, // this is equal to 1
                         'options' => [
                             'stream' => __DIR__ . '/../../log/dk.log',
+                            'log_lifetime' => null, // OPTIONAL
                         ],
                     ],
                 ],
@@ -41,3 +42,30 @@ It is a way to organize writers.
 The `level` key is optional.
 
 The key `stream` is required only if writing into streams/files.
+
+The `options.log_lifetime` key is optional.
+
+## Automatic Log File Deletion
+
+The `options.log_lifetime` key specifies a date after which the specific `writer`'s log files will be **deleted even if not empty**.
+
+The key can be omitted completely or set to `null` in order to skip this feature.
+
+To make use of automatic log file deletion, set the value to an acceptable `DateTimeImmutable` [date/time string](https://www.php.net/manual/en/datetime.formats.php)
+or an integer representing the number of **days**.
+
+> Future dates are ignored.
+
+Examples of date formats:
+
+```php
+'log_lifetime' => null,             // feature disabled
+'log_lifetime' => 90,               // will be converted to `-90 days` so the date is set in the past
+'log_lifetime' => "-90",            // numeric strings are also accepted and will follow same rules as integers
+'log_lifetime' => "30 minutes ago", // valid date
+'log_lifetime' => "last monday",    // valid date
+'log_lifetime' => "monday",         // future date will be ignored
+'log_lifetime' => "next month",     // future date will be ignored
+```
+
+> This feature will delete all relevant log files for the configured `writer`, take care not to misconfigure it in a production environment!

--- a/docs/book/v5/configuring-writer.md
+++ b/docs/book/v5/configuring-writer.md
@@ -51,21 +51,16 @@ The `options.log_lifetime` key specifies a date after which the specific `writer
 
 The key can be omitted completely or set to `null` in order to skip this feature.
 
-To make use of automatic log file deletion, set the value to an acceptable `DateTimeImmutable` [date/time string](https://www.php.net/manual/en/datetime.formats.php)
-or an integer representing the number of **days**.
+To make use of automatic log file deletion, set the value to the number of **days** after which a log file should be deleted.
 
 > Future dates are ignored.
 
-Examples of date formats:
+Examples of values:
 
 ```php
 'log_lifetime' => null,             // feature disabled
 'log_lifetime' => 90,               // will be converted to `-90 days` so the date is set in the past
 'log_lifetime' => "-90",            // numeric strings are also accepted and will follow same rules as integers
-'log_lifetime' => "30 minutes ago", // valid date
-'log_lifetime' => "last monday",    // valid date
-'log_lifetime' => "monday",         // future date will be ignored
-'log_lifetime' => "next month",     // future date will be ignored
 ```
 
 > This feature will delete all relevant log files for the configured `writer`, take care not to misconfigure it in a production environment!

--- a/docs/book/v5/configuring-writer.md
+++ b/docs/book/v5/configuring-writer.md
@@ -53,14 +53,4 @@ The key can be omitted completely or set to `null` in order to skip this feature
 
 To make use of automatic log file deletion, set the value to the number of **days** after which a log file should be deleted.
 
-> Future dates are ignored.
-
-Examples of values:
-
-```php
-'log_lifetime' => null,             // feature disabled
-'log_lifetime' => 90,               // will be converted to `-90 days` so the date is set in the past
-'log_lifetime' => "-90",            // numeric strings are also accepted and will follow same rules as integers
-```
-
 > This feature will delete all relevant log files for the configured `writer`, take care not to misconfigure it in a production environment!

--- a/log.global.php.dist
+++ b/log.global.php.dist
@@ -18,7 +18,9 @@ return [
                                 'name' => 'MyFilter',
                             ],
                         ],
-                        'log_lifetime' => null, // optional
+                        // optional key that can be omitted or set to null to disable auto-deletion of logs
+                        // accepts an integer representing the number of days after which a log will be deleted
+                        'log_lifetime' => null,
                     ],
                 ],
             ],

--- a/log.global.php.dist
+++ b/log.global.php.dist
@@ -18,6 +18,7 @@ return [
                                 'name' => 'MyFilter',
                             ],
                         ],
+                        'log_lifetime' => null, // optional
                     ],
                 ],
             ],

--- a/src/Factory/LoggerAbstractServiceFactory.php
+++ b/src/Factory/LoggerAbstractServiceFactory.php
@@ -15,6 +15,7 @@ use function count;
 use function date;
 use function explode;
 use function is_array;
+use function pathinfo;
 use function preg_match_all;
 use function str_replace;
 
@@ -103,7 +104,9 @@ class LoggerAbstractServiceFactory extends LoggerServiceFactory implements Abstr
         if (isset($config['writers'])) {
             foreach ($config['writers'] as $index => $writerConfig) {
                 if (! empty($writerConfig['options']['stream'])) {
-                    $config['writers'][$index]['options']['stream'] = self::parseVariables(
+                    $config['writers'][$index]['options']['stream_format'] =
+                        pathinfo($writerConfig['options']['stream'])['basename'];
+                    $config['writers'][$index]['options']['stream']        = self::parseVariables(
                         $writerConfig['options']['stream']
                     );
                 }

--- a/src/Writer/Stream.php
+++ b/src/Writer/Stream.php
@@ -15,6 +15,7 @@ use Traversable;
 
 use function chmod;
 use function dirname;
+use function error_log;
 use function fclose;
 use function file_exists;
 use function filemtime;
@@ -23,6 +24,8 @@ use function fwrite;
 use function get_resource_type;
 use function gettype;
 use function is_array;
+use function is_dir;
+use function is_link;
 use function is_numeric;
 use function is_resource;
 use function is_string;
@@ -39,6 +42,7 @@ use function time;
 use function touch;
 use function unlink;
 
+use const PATHINFO_DIRNAME;
 use const PHP_EOL;
 
 class Stream extends AbstractWriter
@@ -65,10 +69,11 @@ class Stream extends AbstractWriter
         mixed $streamOrUrl,
         ?string $mode = null,
         ?string $logSeparator = null,
-        ?int $filePermissions = null,
-        ?string $logLifetime = null,
-        ?string $streamFormat = null,
+        ?int $filePermissions = null
     ) {
+        $logLifetime  = null;
+        $streamFormat = null;
+
         if ($streamOrUrl instanceof Traversable) {
             $streamOrUrl = iterator_to_array($streamOrUrl);
         }
@@ -133,10 +138,8 @@ class Stream extends AbstractWriter
             $this->setLogSeparator($logSeparator);
         }
 
-        if (null !== $logLifetime) {
-            if (is_numeric($logLifetime)) {
-                $logLifetime = ($logLifetime > 0 ? '-' . $logLifetime : $logLifetime) . ' days';
-            }
+        if (is_numeric($logLifetime)) {
+            $logLifetime = ($logLifetime > 0 ? '-' . $logLifetime : $logLifetime) . ' days';
 
             try {
                 $logLifetime = (new DateTimeImmutable($logLifetime))->getTimestamp();
@@ -208,21 +211,34 @@ class Stream extends AbstractWriter
         }
         $streamData = stream_get_meta_data($this->stream);
 
-        $path     = $streamData['uri'];
-        $uriParts = pathinfo($path);
+        $path      = $streamData['uri'];
+        $directory = pathinfo($path, PATHINFO_DIRNAME);
 
-        $files   = scandir($uriParts['dirname']);
-        $matches = preg_grep('/^' . $this->streamFormat . '$/', $files);
+        if (! is_dir($directory)) {
+            error_log("{$directory} is not a directory");
+            return;
+        }
+
+        $files   = scandir($directory) ?: [];
+        $matches = preg_grep('/^' . $this->streamFormat . '$/', $files) ?: [];
 
         foreach ($matches as $match) {
-            $match         = sprintf('%s/%s', $uriParts['dirname'], $match);
+            $match = sprintf('%s/%s', $directory, $match);
+
+            if (is_link($match)) {
+                continue;
+            }
+
             $fileTimestamp = filemtime($match);
 
             if (
                 $fileTimestamp !== false
                 && $fileTimestamp < $this->logLifetime
+                && is_writable($directory)
             ) {
-                unlink($match);
+                if (! @unlink($match)) {
+                    error_log("{$match} could not be deleted");
+                }
             }
         }
     }

--- a/src/Writer/Stream.php
+++ b/src/Writer/Stream.php
@@ -4,9 +4,11 @@ declare(strict_types=1);
 
 namespace Dot\Log\Writer;
 
+use DateTimeImmutable;
 use Dot\Log\Exception\InvalidArgumentException;
 use Dot\Log\Exception\RuntimeException;
 use ErrorException;
+use Exception;
 use Laminas\Stdlib\ErrorHandler;
 use Psr\Container\ContainerExceptionInterface;
 use Traversable;
@@ -15,17 +17,27 @@ use function chmod;
 use function dirname;
 use function fclose;
 use function file_exists;
+use function filemtime;
 use function fopen;
 use function fwrite;
 use function get_resource_type;
 use function gettype;
 use function is_array;
+use function is_numeric;
 use function is_resource;
 use function is_string;
 use function is_writable;
 use function iterator_to_array;
+use function pathinfo;
+use function preg_grep;
+use function preg_match_all;
+use function scandir;
 use function sprintf;
+use function str_replace;
+use function stream_get_meta_data;
+use function time;
 use function touch;
+use function unlink;
 
 use const PHP_EOL;
 
@@ -41,6 +53,10 @@ class Stream extends AbstractWriter
      */
     protected mixed $stream;
 
+    protected ?int $logLifetime = null;
+
+    protected ?string $streamFormat = null;
+
     /**
      * @throws ContainerExceptionInterface
      * @throws ErrorException
@@ -49,14 +65,17 @@ class Stream extends AbstractWriter
         mixed $streamOrUrl,
         ?string $mode = null,
         ?string $logSeparator = null,
-        ?int $filePermissions = null
+        ?int $filePermissions = null,
+        ?string $logLifetime = null,
+        ?string $streamFormat = null,
     ) {
         if ($streamOrUrl instanceof Traversable) {
             $streamOrUrl = iterator_to_array($streamOrUrl);
         }
-
         if (is_array($streamOrUrl)) {
             parent::__construct($streamOrUrl);
+            $logLifetime     = $streamOrUrl['log_lifetime'] ?? null;
+            $streamFormat    = $streamOrUrl['stream_format'] ?? null;
             $mode            = $streamOrUrl['mode'] ?? null;
             $logSeparator    = $streamOrUrl['log_separator'] ?? null;
             $filePermissions = $streamOrUrl['chmod'] ?? $filePermissions;
@@ -113,6 +132,27 @@ class Stream extends AbstractWriter
         if (null !== $logSeparator) {
             $this->setLogSeparator($logSeparator);
         }
+
+        if (null !== $logLifetime) {
+            if (is_numeric($logLifetime)) {
+                $logLifetime = ($logLifetime > 0 ? '-' . $logLifetime : $logLifetime) . ' days';
+            }
+
+            try {
+                $logLifetime = (new DateTimeImmutable($logLifetime))->getTimestamp();
+                if ($logLifetime >= time()) {
+                    $logLifetime = null;
+                }
+            } catch (Exception $e) {
+                $logLifetime = null;
+            }
+
+            if ($logLifetime !== null && $streamFormat !== null) {
+                $this->streamFormat = $streamFormat;
+            }
+
+            $this->logLifetime = $logLifetime;
+        }
     }
 
     /**
@@ -146,8 +186,44 @@ class Stream extends AbstractWriter
      */
     public function shutdown(): void
     {
+        if ($this->logLifetime !== null && $this->streamFormat !== null) {
+            $this->removeOldLogs();
+        }
+
         if (is_resource($this->stream)) {
             fclose($this->stream);
+        }
+    }
+
+    protected function removeOldLogs(): void
+    {
+        preg_match_all('/{([a-z])}/i', $this->streamFormat, $matches);
+
+        if (! empty($matches[1])) {
+            foreach ($matches[1] as $match) {
+                $this->streamFormat = str_replace('{' . $match . '}', '\d+', $this->streamFormat);
+            }
+
+            $this->streamFormat = str_replace('.', '\.', $this->streamFormat);
+        }
+        $streamData = stream_get_meta_data($this->stream);
+
+        $path     = $streamData['uri'];
+        $uriParts = pathinfo($path);
+
+        $files   = scandir($uriParts['dirname']);
+        $matches = preg_grep('/^' . $this->streamFormat . '$/', $files);
+
+        foreach ($matches as $match) {
+            $match         = sprintf('%s/%s', $uriParts['dirname'], $match);
+            $fileTimestamp = filemtime($match);
+
+            if (
+                $fileTimestamp !== false
+                && $fileTimestamp < $this->logLifetime
+            ) {
+                unlink($match);
+            }
         }
     }
 }


### PR DESCRIPTION
|    Q        |   A
|------------ | ------
| New Feature | yes
| RFC         | yes
| BC Break    | no

An initial version of the feature requested in #79 .

This PR only adds an extra method to the existing `Stream` `Writer` class and the extra config and processing it requires.

A few things to mention:

1. I went with the configuration per writer as it would allow setting different (or none at all) deletion times independent of other configured loggers or writers, I'll go over more details below. 
    - let me know if this is maybe too much and a simpler "delete all logs" approach is preferred.
2. Since it's the default writer shipped with the package I went with editing the `Stream` class
    - also didn't modify the `AbstractWriter` itself as I didn't want to force any custom writers to have this feature as well
    - do you think it should be expanded to a separate (service?) class instead?
3. Files to be deleted are selected by matching the configured writer's stream format (examples below).
4. I've expanded the deletion value to accept other `DateTimeImmutable` formats, but the `int` values mentioned in the issue work, defaulting to N days - again, let me know if this is unnecessary.

Here's a small example for the following logger config:

```php
    'dot_log'          => [
        'loggers' => [
            'error_writer' => [
                //...
                'options' => [
                    'stream' => __DIR__ . '/../../log/error-log-{Y}-{m}-{d}.log',
                    'log_lifetime' => null,
                    //...
                ],
            ],
            'custom_writer' => [
                //...
                'options' => [
                    'stream'       => __DIR__ . '/../../log/{Y}-{m}-{d}.log',
                    'log_lifetime' => 30,
                    //...
                ]
            ],
            'second_custom_writer' => [
                //...
                'options' => [
                    'stream'       => __DIR__ . '/../../log/{Y}-{m}-{d}_custom_log.log',
                    'log_lifetime' => '12 hours ago',
                    //...
                ]
            ]
        ],
    ]
```

And the following existing log files:

```
2025-06-10.log
2025-10-09.log
2025-10-10.log
error-log-2025-10-09.log
error-log-2025-10-10.log
2025-10-09_custom_log.log
2025-10-10_custom_log.log
```

For logs written during 2025.10.10 the flow is as follows:

Using `error_writer` to write will not trigger any deletion as `log_lifetime` is null (can be omitted completely).

Using `custom_writer` will only delete `2025-06-10.log` because the set value will be converted to "30 days ago", so `2025-10-09` is too new. All other log format untouched.

Using `second_custom_writer` will delete `2025-10-09_custom_log.log` only (presuming 12 hours have indeed passed).